### PR TITLE
docs: Fix simple typo, wether -> whether

### DIFF
--- a/docs/archive/browser/batch.rst
+++ b/docs/archive/browser/batch.rst
@@ -10,9 +10,9 @@ following keys:
 
 - ``page`` - the displayed page name, normally a number, or a character.
 
-- ``current`` - Flag wether page is current page or not.
+- ``current`` - Flag whether page is current page or not.
 
-- ``visible`` - Flag wether page is visible or not.
+- ``visible`` - Flag whether page is visible or not.
 
 - ``href`` - href attribute URL.
 

--- a/src/cone/app/browser/layout.py
+++ b/src/cone/app/browser/layout.py
@@ -171,7 +171,7 @@ class MainMenu(Tile):
         # check for default child id if no curpath
         if not curpath and root_props.default_child:
             curpath = root_props.default_child
-        # check wether to render mainmenu item title
+        # check whether to render mainmenu item title
         empty_title = root_props.mainmenu_empty_title
         # XXX: icons
         for key in root.keys():

--- a/src/cone/app/tests/test_browser_batch.py
+++ b/src/cone/app/tests/test_browser_batch.py
@@ -21,8 +21,8 @@ class TestBrowserBatch(TileTestCase):
         # providing the following keys:
         # - ``page`` - the displayed page name, normally a number, or a
         #              character.
-        # - ``current`` - Flag wether page is current page or not.
-        # - ``visible`` - Flag wether page is visible or not.
+        # - ``current`` - Flag whether page is current page or not.
+        # - ``visible`` - Flag whether page is visible or not.
         # - ``href`` - href attribute URL.
         # - ``target`` - ajax target URL.
         # - ``url`` - Target URL. B/C. Use dedicated ``href`` and ``target``.


### PR DESCRIPTION
There is a small typo in docs/archive/browser/batch.rst, src/cone/app/browser/layout.py, src/cone/app/tests/test_browser_batch.py.

Should read `whether` rather than `wether`.

